### PR TITLE
lockdownd: Use an actual service port instead of 0

### DIFF
--- a/src/services/lockdownd.rs
+++ b/src/services/lockdownd.rs
@@ -253,9 +253,12 @@ impl LockdowndClient<'_> {
             return Err(result);
         }
 
+        let service_struct: &unsafe_bindings::lockdownd_service_descriptor =
+            unsafe { &*service };
+
         Ok(LockdowndService {
             pointer: service,
-            port: 0,
+            port: service_struct.port as u32,
             phantom: std::marker::PhantomData,
         })
     }


### PR DESCRIPTION
Use an actual service port from the given struct instead of a placeholder.