### PR TITLE
Fix passing strings to C

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -1,5 +1,6 @@
 // jkcoxson
 
+use std::ffi::CString;
 use std::os::raw::c_char;
 
 use crate::services::lockdownd::LockdowndService;
@@ -48,13 +49,15 @@ impl ServiceClient<'_> {
         label: impl Into<String>,
     ) -> Result<(Self, i32), ServiceError> {
         let mut pointer = std::ptr::null_mut();
+        let service_name_c_string = CString::new(service_name.into()).unwrap();
+        let label_c_string = CString::new(label.into()).unwrap();
         let mut error_code = 0;
         let result = unsafe {
             unsafe_bindings::service_client_factory_start_service(
                 device.pointer,
-                service_name.into().as_ptr() as *const c_char,
+                service_name_c_string.as_ptr(),
                 &mut pointer,
-                label.into().as_ptr() as *const c_char,
+                label_c_string.as_ptr(),
                 None,
                 &mut error_code,
             )

--- a/src/services/diagnostics_relay.rs
+++ b/src/services/diagnostics_relay.rs
@@ -1,6 +1,7 @@
 // jkcoxson
 
 use libc::c_uint;
+use std::ffi::CString;
 
 use crate::{
     bindings as unsafe_bindings, error::DiagnosticsRelayError, idevice::Device,
@@ -58,11 +59,12 @@ impl DiagnosticsRelay<'_> {
         label: impl Into<String>,
     ) -> Result<Self, DiagnosticsRelayError> {
         let mut pointer = std::ptr::null_mut();
+        let label_c_string = CString::new(label.into()).unwrap();
         let result = unsafe {
             unsafe_bindings::diagnostics_relay_client_start_service(
                 device.pointer,
                 &mut pointer,
-                label.into().as_ptr() as *const std::os::raw::c_char,
+                label_c_string.as_ptr(),
             )
         }
         .into();
@@ -160,10 +162,11 @@ impl DiagnosticsRelay<'_> {
         type_: impl Into<String>,
     ) -> Result<Plist, DiagnosticsRelayError> {
         let mut plist = std::ptr::null_mut();
+        let type_c_string = CString::new(type_.into()).unwrap();
         let result = unsafe {
             unsafe_bindings::diagnostics_relay_request_diagnostics(
                 self.pointer,
-                type_.into().as_ptr() as *const std::os::raw::c_char,
+                type_c_string.as_ptr(),
                 &mut plist,
             )
         }
@@ -215,11 +218,14 @@ impl DiagnosticsRelay<'_> {
         entry_class: impl Into<String>,
     ) -> Result<Plist, DiagnosticsRelayError> {
         let mut plist = std::ptr::null_mut();
+        let entry_name_c_string = CString::new(entry_name.into()).unwrap();
+        let entry_class_c_string = CString::new(entry_class.into()).unwrap();
+
         let result = unsafe {
             unsafe_bindings::diagnostics_relay_query_ioregistry_entry(
                 self.pointer,
-                entry_name.into().as_ptr() as *const std::os::raw::c_char,
-                entry_class.into().as_ptr() as *const std::os::raw::c_char,
+                entry_name_c_string.as_ptr(),
+                entry_class_c_string.as_ptr(),
                 &mut plist,
             )
         }
@@ -244,10 +250,11 @@ impl DiagnosticsRelay<'_> {
         plane: impl Into<String>,
     ) -> Result<Plist, DiagnosticsRelayError> {
         let mut plist = std::ptr::null_mut();
+        let plane_c_string = CString::new(plane.into()).unwrap();
         let result = unsafe {
             unsafe_bindings::diagnostics_relay_query_ioregistry_plane(
                 self.pointer,
-                plane.into().as_ptr() as *const std::os::raw::c_char,
+                plane_c_string.as_ptr(),
                 &mut plist,
             )
         }

--- a/src/services/file_relay.rs
+++ b/src/services/file_relay.rs
@@ -52,11 +52,12 @@ impl FileRelay<'_> {
         label: impl Into<String>,
     ) -> Result<Self, FileRelayError> {
         let mut pointer = std::ptr::null_mut();
+        let label_c_string = CString::new(label.into()).unwrap();
         let result = unsafe {
             unsafe_bindings::file_relay_client_start_service(
                 device.pointer,
                 &mut pointer,
-                label.into().as_ptr() as *const c_char,
+                label_c_string.as_ptr(),
             )
         }
         .into();

--- a/src/services/heartbeat.rs
+++ b/src/services/heartbeat.rs
@@ -39,10 +39,13 @@ impl HeartbeatClient {
     /// ***Verified:*** False
     pub fn new(device: &Device, label: impl Into<String>) -> Result<Self, HeartbeatError> {
         let mut pointer = unsafe { std::mem::zeroed() };
-        let label_c_str = CString::new(label.into()).unwrap();
-        let label_ptr = label_c_str.as_ptr();
+        let label_c_string = CString::new(label.into()).unwrap();
         let result = unsafe {
-            unsafe_bindings::heartbeat_client_start_service(device.pointer, &mut pointer, label_ptr)
+            unsafe_bindings::heartbeat_client_start_service(
+                device.pointer,
+                &mut pointer,
+                label_c_string.as_ptr(),
+            )
         }
         .into();
         if result != HeartbeatError::Success {

--- a/src/services/house_arrest.rs
+++ b/src/services/house_arrest.rs
@@ -1,5 +1,7 @@
 // jkcoxson
 
+use std::ffi::CString;
+
 use crate::{
     bindings as unsafe_bindings, error::HouseArrestError, idevice::Device,
     services::lockdownd::LockdowndService,
@@ -53,11 +55,12 @@ impl HouseArrest<'_> {
         label: impl Into<String>,
     ) -> Result<Self, HouseArrestError> {
         let mut pointer = std::ptr::null_mut();
+        let label_c_string = CString::new(label.into()).unwrap();
         let result = unsafe {
             unsafe_bindings::house_arrest_client_start_service(
                 device.pointer,
                 &mut pointer,
-                label.into().as_ptr() as *const std::os::raw::c_char,
+                label_c_string.as_ptr(),
             )
         }
         .into();
@@ -114,11 +117,14 @@ impl HouseArrest<'_> {
         command: impl Into<String>,
         app_id: impl Into<String>,
     ) -> Result<Plist, HouseArrestError> {
+        let command_c_string = CString::new(command.into()).unwrap();
+        let app_id_c_string = CString::new(app_id.into()).unwrap();
+
         let result = unsafe {
             unsafe_bindings::house_arrest_send_command(
                 self.pointer,
-                command.into().as_ptr() as *const std::os::raw::c_char,
-                app_id.into().as_ptr() as *const std::os::raw::c_char,
+                command_c_string.as_ptr(),
+                app_id_c_string.as_ptr(),
             )
         }
         .into();

--- a/src/services/instproxy.rs
+++ b/src/services/instproxy.rs
@@ -27,15 +27,15 @@ impl InstProxyClient<'_> {
     ///
     /// ***Verified:*** False
     pub fn new(device: &Device, label: impl Into<String>) -> Result<Self, InstProxyError> {
-        let label = label.into();
+        let label: String = label.into();
         let mut instproxy_client = unsafe { std::mem::zeroed() };
-        let label_c_str = std::ffi::CString::new(label.clone()).unwrap();
+        let label_c_string = CString::new(label.clone()).unwrap();
         info!("Creating instproxy client for {}", device.get_udid());
         let result = unsafe {
             unsafe_bindings::instproxy_client_start_service(
                 device.pointer,
                 &mut instproxy_client,
-                label_c_str.as_ptr(),
+                label_c_string.as_ptr(),
             )
         }
         .into();
@@ -193,18 +193,14 @@ impl InstProxyClient<'_> {
         client_options: Option<Plist>,
     ) -> Result<(), InstProxyError> {
         info!("Instproxy install");
-        let pkg_path_c_str = std::ffi::CString::new(pkg_path.into()).unwrap();
+        let pkg_path_c_string = CString::new(pkg_path.into()).unwrap();
 
-        let ptr = if let Some(client_options) = client_options {
-            client_options.get_pointer()
-        } else {
-            std::ptr::null_mut()
-        };
+        let ptr = client_options.map_or(std::ptr::null_mut(), |v| v.get_pointer());
 
         let result = unsafe {
             unsafe_bindings::instproxy_install(
                 self.pointer,
-                pkg_path_c_str.as_ptr(),
+                pkg_path_c_string.as_ptr(),
                 ptr,
                 None, // I feel like this will segfault. The bindings are probably wrong.
                 std::ptr::null_mut(),
@@ -232,18 +228,14 @@ impl InstProxyClient<'_> {
         client_options: Option<Plist>,
     ) -> Result<(), InstProxyError> {
         info!("Instproxy upgrade");
-        let pkg_path_c_str = std::ffi::CString::new(pkg_path.into()).unwrap();
+        let pkg_path_c_string = CString::new(pkg_path.into()).unwrap();
 
-        let ptr = if let Some(client_options) = client_options {
-            client_options.get_pointer()
-        } else {
-            std::ptr::null_mut()
-        };
+        let ptr = client_options.map_or(std::ptr::null_mut(), |v| v.get_pointer());
 
         let result = unsafe {
             unsafe_bindings::instproxy_upgrade(
                 self.pointer,
-                pkg_path_c_str.as_ptr(),
+                pkg_path_c_string.as_ptr(),
                 ptr,
                 None, // I feel like this will segfault. The bindings are probably wrong.
                 std::ptr::null_mut(),
@@ -271,18 +263,14 @@ impl InstProxyClient<'_> {
         client_options: Option<Plist>,
     ) -> Result<(), InstProxyError> {
         info!("Instproxy uninstall");
-        let app_id_c_str = std::ffi::CString::new(app_id.into()).unwrap();
+        let app_id_c_string = CString::new(app_id.into()).unwrap();
 
-        let ptr = if let Some(client_options) = client_options {
-            client_options.get_pointer()
-        } else {
-            std::ptr::null_mut()
-        };
+        let ptr = client_options.map_or(std::ptr::null_mut(), |v| v.get_pointer());
 
         let result = unsafe {
             unsafe_bindings::instproxy_uninstall(
                 self.pointer,
-                app_id_c_str.as_ptr(),
+                app_id_c_string.as_ptr(),
                 ptr,
                 None, // I feel like this will segfault. The bindings are probably wrong.
                 std::ptr::null_mut(),
@@ -307,11 +295,8 @@ impl InstProxyClient<'_> {
         let mut res_plist: unsafe_bindings::plist_t = unsafe { std::mem::zeroed() };
         info!("Instproxy lookup archives");
 
-        let ptr = if let Some(client_options) = client_options {
-            client_options.get_pointer()
-        } else {
-            std::ptr::null_mut()
-        };
+        let ptr = client_options.map_or(std::ptr::null_mut(), |v| v.get_pointer());
+
         let result = unsafe {
             unsafe_bindings::instproxy_lookup_archives(self.pointer, ptr, &mut res_plist)
         }
@@ -337,18 +322,14 @@ impl InstProxyClient<'_> {
         client_options: Option<Plist>,
     ) -> Result<(), InstProxyError> {
         info!("Instproxy archive");
-        let app_id_c_str = std::ffi::CString::new(app_id.into()).unwrap();
+        let app_id_c_string = CString::new(app_id.into()).unwrap();
 
-        let ptr = if let Some(client_options) = client_options {
-            client_options.get_pointer()
-        } else {
-            std::ptr::null_mut()
-        };
+        let ptr = client_options.map_or(std::ptr::null_mut(), |v| v.get_pointer());
 
         let result = unsafe {
             unsafe_bindings::instproxy_archive(
                 self.pointer,
-                app_id_c_str.as_ptr(),
+                app_id_c_string.as_ptr(),
                 ptr,
                 None, // I feel like this will segfault. The bindings are probably wrong.
                 std::ptr::null_mut(),
@@ -375,18 +356,14 @@ impl InstProxyClient<'_> {
         client_options: Option<Plist>,
     ) -> Result<(), InstProxyError> {
         info!("Instproxy restore");
-        let app_id_c_str = std::ffi::CString::new(app_id.into()).unwrap();
+        let app_id_c_string = CString::new(app_id.into()).unwrap();
 
-        let ptr = if let Some(client_options) = client_options {
-            client_options.get_pointer()
-        } else {
-            std::ptr::null_mut()
-        };
+        let ptr = client_options.map_or(std::ptr::null_mut(), |v| v.get_pointer());
 
         let result = unsafe {
             unsafe_bindings::instproxy_restore(
                 self.pointer,
-                app_id_c_str.as_ptr(),
+                app_id_c_string.as_ptr(),
                 ptr,
                 None, // I feel like this will segfault. The bindings are probably wrong.
                 std::ptr::null_mut(),
@@ -413,18 +390,14 @@ impl InstProxyClient<'_> {
         client_options: Option<Plist>,
     ) -> Result<(), InstProxyError> {
         info!("Instproxy remove archive");
-        let app_id_c_str = std::ffi::CString::new(app_id.into()).unwrap();
+        let app_id_c_string = CString::new(app_id.into()).unwrap();
 
-        let ptr = if let Some(client_options) = client_options {
-            client_options.get_pointer()
-        } else {
-            std::ptr::null_mut()
-        };
+        let ptr = client_options.map_or(std::ptr::null_mut(), |v| v.get_pointer());
 
         let result = unsafe {
             unsafe_bindings::instproxy_remove_archive(
                 self.pointer,
-                app_id_c_str.as_ptr(),
+                app_id_c_string.as_ptr(),
                 ptr,
                 None, // I feel like this will segfault. The bindings are probably wrong.
                 std::ptr::null_mut(),
@@ -495,7 +468,7 @@ impl InstProxyClient<'_> {
         &self,
         bundle_identifier: impl Into<String>,
     ) -> Result<String, InstProxyError> {
-        let bundle_id = std::ffi::CString::new(bundle_identifier.into()).unwrap();
+        let bundle_id_c_string = CString::new(bundle_identifier.into()).unwrap();
         // This is kinda horrifying, could use a refractor
         let to_fill = CString::new("").unwrap();
         let mut to_fill_bytes = to_fill.into_raw();
@@ -505,7 +478,7 @@ impl InstProxyClient<'_> {
         let result = unsafe {
             unsafe_bindings::instproxy_client_get_path_for_bundle_identifier(
                 self.pointer,
-                bundle_id.as_ptr(),
+                bundle_id_c_string.as_ptr(),
                 to_fill_ptr,
             )
         }

--- a/src/services/misagent.rs
+++ b/src/services/misagent.rs
@@ -1,11 +1,10 @@
 // jkcoxson
 
-use std::os::raw::c_char;
-
 use crate::{
     bindings as unsafe_bindings, error::MisagentError, idevice::Device,
     services::lockdownd::LockdowndService,
 };
+use std::{ffi::CString, os::raw::c_char};
 
 use plist_plus::Plist;
 
@@ -115,10 +114,9 @@ impl MisagentClient<'_> {
     ///
     /// ***Verified:*** False
     pub fn remove(&self, id: impl Into<String>) -> Result<(), MisagentError> {
-        let result = unsafe {
-            unsafe_bindings::misagent_remove(self.pointer, id.into().as_ptr() as *const c_char)
-        }
-        .into();
+        let id_c_string = CString::new(id.into()).unwrap();
+        let result =
+            unsafe { unsafe_bindings::misagent_remove(self.pointer, id_c_string.as_ptr()) }.into();
         if result != MisagentError::Success {
             return Err(result);
         }

--- a/src/services/mobile_activation.rs
+++ b/src/services/mobile_activation.rs
@@ -1,6 +1,6 @@
 // jkcoxson
 
-use std::os::raw::c_char;
+use std::ffi::CString;
 
 use crate::{
     bindings as unsafe_bindings, error::MobileActivationError, idevice::Device,
@@ -60,13 +60,14 @@ impl MobileActivationClient<'_> {
         device: &Device,
         label: impl Into<String>,
     ) -> Result<Self, MobileActivationError> {
+        let label_c_string = CString::new(label.into()).unwrap();
         let mut client = unsafe { std::mem::zeroed() };
 
         let result = unsafe {
             unsafe_bindings::mobileactivation_client_start_service(
                 device.pointer,
                 &mut client,
-                label.into().as_ptr() as *const c_char,
+                label_c_string.as_ptr(),
             )
         }
         .into();

--- a/src/services/notification_proxy.rs
+++ b/src/services/notification_proxy.rs
@@ -1,5 +1,7 @@
 // jkcoxson
 
+use std::ffi::CString;
+
 use crate::bindings as unsafe_bindings;
 use crate::error::NpError;
 use crate::idevice::Device;
@@ -46,12 +48,14 @@ impl NotificationProxyClient<'_> {
     ///
     /// ***Verified:*** False
     pub fn start_service(device: &Device, label: impl Into<String>) -> Result<Self, NpError> {
+        let label_c_string = CString::new(label.into()).unwrap();
+
         let mut pointer = std::ptr::null_mut();
         let result = unsafe {
             unsafe_bindings::np_client_start_service(
                 device.pointer,
                 &mut pointer,
-                label.into().as_ptr() as *const std::os::raw::c_char,
+                label_c_string.as_ptr(),
             )
         }
         .into();
@@ -74,11 +78,9 @@ impl NotificationProxyClient<'_> {
     ///
     /// ***Verified:*** False
     pub fn post_notification(&self, notification: &str) -> Result<(), NpError> {
+        let notification_c_string = CString::new(notification).unwrap();
         let result = unsafe {
-            unsafe_bindings::np_post_notification(
-                self.pointer,
-                notification.as_ptr() as *const std::os::raw::c_char,
-            )
+            unsafe_bindings::np_post_notification(self.pointer, notification_c_string.as_ptr())
         }
         .into();
 
@@ -97,11 +99,9 @@ impl NotificationProxyClient<'_> {
     ///
     /// ***Verified:*** False
     pub fn observe_notification(&self, notification: &str) -> Result<(), NpError> {
+        let notification_c_string = CString::new(notification).unwrap();
         let result = unsafe {
-            unsafe_bindings::np_observe_notification(
-                self.pointer,
-                notification.as_ptr() as *const std::os::raw::c_char,
-            )
+            unsafe_bindings::np_observe_notification(self.pointer, notification_c_string.as_ptr())
         }
         .into();
 

--- a/src/services/preboard.rs
+++ b/src/services/preboard.rs
@@ -1,6 +1,6 @@
 // Prepare to be boarded
 
-use std::os::raw::c_char;
+use std::ffi::CString;
 
 use crate::{
     bindings as unsafe_bindings, error::PreboardError, idevice::Device,
@@ -52,11 +52,12 @@ impl PreboardClient<'_> {
     /// ***Verified:*** False
     pub fn start_service(device: &Device, label: impl Into<String>) -> Result<Self, PreboardError> {
         let mut pointer = std::ptr::null_mut();
+        let label_c_string = CString::new(label.into()).unwrap();
         let result = unsafe {
             unsafe_bindings::preboard_client_start_service(
                 device.pointer,
                 &mut pointer,
-                label.into().as_ptr() as *const c_char,
+                label_c_string.as_ptr(),
             )
         }
         .into();

--- a/src/services/restored.rs
+++ b/src/services/restored.rs
@@ -1,6 +1,6 @@
 // jkcoxson
 
-use std::os::raw::c_char;
+use std::ffi::CString;
 
 use crate::{bindings as unsafe_bindings, error::RestoredError, idevice::Device};
 
@@ -23,11 +23,12 @@ impl RestoredClient<'_> {
     /// ***Verified:*** False
     pub fn new(device: &Device, label: impl Into<String>) -> Result<Self, RestoredError> {
         let mut pointer = unsafe { std::mem::zeroed() };
+        let label_c_string = CString::new(label.into()).unwrap();
         let result = unsafe {
             unsafe_bindings::restored_client_new(
                 device.pointer,
                 &mut pointer,
-                label.into().as_ptr() as *const c_char,
+                label_c_string.as_ptr(),
             )
         }
         .into();
@@ -75,12 +76,9 @@ impl RestoredClient<'_> {
     /// ***Verified:*** False
     pub fn query_value(&self, key: impl Into<String>) -> Result<Plist, RestoredError> {
         let mut value = std::ptr::null_mut();
+        let key_c_string = CString::new(key.into()).unwrap();
         let result = unsafe {
-            unsafe_bindings::restored_query_value(
-                self.pointer,
-                key.into().as_ptr() as *const c_char,
-                &mut value,
-            )
+            unsafe_bindings::restored_query_value(self.pointer, key_c_string.as_ptr(), &mut value)
         }
         .into();
         if result != RestoredError::Success {
@@ -99,12 +97,9 @@ impl RestoredClient<'_> {
     /// ***Verified:*** False
     pub fn get_value(&self, key: impl Into<String>) -> Result<Plist, RestoredError> {
         let mut value = std::ptr::null_mut();
+        let key_c_string = CString::new(key.into()).unwrap();
         let result = unsafe {
-            unsafe_bindings::restored_get_value(
-                self.pointer,
-                key.into().as_ptr() as *const c_char,
-                &mut value,
-            )
+            unsafe_bindings::restored_get_value(self.pointer, key_c_string.as_ptr(), &mut value)
         }
         .into();
         if result != RestoredError::Success {
@@ -211,11 +206,9 @@ impl RestoredClient<'_> {
     ///
     /// ***Verified:*** False
     pub fn set_label(&self, label: impl Into<String>) {
+        let label_c_string = CString::new(label.into()).unwrap();
         unsafe {
-            unsafe_bindings::restored_client_set_label(
-                self.pointer,
-                label.into().as_ptr() as *const c_char,
-            )
+            unsafe_bindings::restored_client_set_label(self.pointer, label_c_string.as_ptr())
         };
     }
 }

--- a/src/services/screenshotr.rs
+++ b/src/services/screenshotr.rs
@@ -1,6 +1,6 @@
 // jkcoxson
 
-use std::os::raw::c_char;
+use std::ffi::CString;
 
 use log::info;
 
@@ -57,11 +57,12 @@ impl ScreenshotrClient<'_> {
         label: impl Into<String>,
     ) -> Result<Self, ScreenshotrError> {
         let mut pointer = std::ptr::null_mut();
+        let label_c_string = CString::new(label.into()).unwrap();
         let result = unsafe {
             unsafe_bindings::screenshotr_client_start_service(
                 device.pointer,
                 &mut pointer,
-                label.into().as_ptr() as *const c_char,
+                label_c_string.as_ptr(),
             )
         }
         .into();

--- a/src/services/web_inspector.rs
+++ b/src/services/web_inspector.rs
@@ -1,6 +1,6 @@
 // jkcoxson
 
-use std::os::raw::c_char;
+use std::ffi::CString;
 
 use crate::{
     bindings as unsafe_bindings, error::WebInspectorError, idevice::Device,
@@ -59,12 +59,13 @@ impl WebInspectorClient<'_> {
         label: impl Into<String>,
     ) -> Result<Self, WebInspectorError> {
         let mut pointer = std::ptr::null_mut();
+        let label_c_string = CString::new(label.into()).unwrap();
 
         let result = unsafe {
             unsafe_bindings::webinspector_client_start_service(
                 device.pointer,
                 &mut pointer,
-                label.into().as_ptr() as *const c_char,
+                label_c_string.as_ptr(),
             )
         }
         .into();


### PR DESCRIPTION
Passing Rust strings to the C side is not always correctly done. There are some cases, when a pointer to a Rust string gets passed, however it must be converted to a CString first. Also a CString must be bound a local variable before calling `as_ptr` method, or else it gets deallocated and [a pointer gets invalid](https://doc.rust-lang.org/std/ffi/struct.CString.html#method.as_ptr). I’ve also refactored some related code to make it more consistent.