### PR TITLE
Use slices as arguments

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,6 +1,5 @@
 // jkcoxson
 
-use std::convert::TryInto;
 use std::marker::PhantomData;
 use std::os::raw::c_char;
 
@@ -53,13 +52,13 @@ impl DeviceConnection<'_> {
     /// The number of bytes sent
     ///
     /// ***Verified:*** False
-    pub fn send(&self, data: Vec<u8>) -> Result<u32, IdeviceError> {
+    pub fn send(&self, data: &[u8]) -> Result<u32, IdeviceError> {
         let mut to_fill = unsafe { std::mem::zeroed() };
         let result = unsafe {
             unsafe_bindings::idevice_connection_send(
                 self.pointer,
                 data.as_ptr() as *const c_char,
-                data.len().try_into().unwrap(),
+                data.len() as u32,
                 &mut to_fill,
             )
         }

--- a/src/services/mobile_backup.rs
+++ b/src/services/mobile_backup.rs
@@ -427,7 +427,7 @@ impl MobileBackup2Client<'_> {
     /// The bytes sent
     ///
     /// ***Verified:*** False
-    pub fn send_raw(&self, data: Vec<u8>) -> Result<u32, MobileBackup2Error> {
+    pub fn send_raw(&self, data: &[u8]) -> Result<u32, MobileBackup2Error> {
         let mut sent = 0;
         let result = unsafe {
             unsafe_bindings::mobilebackup2_send_raw(
@@ -478,7 +478,7 @@ impl MobileBackup2Client<'_> {
     /// * The version of the iOS device
     ///
     /// ***Verified:*** False
-    pub fn version_exchange(&self, mut versions: Vec<f64>) -> Result<f64, MobileBackup2Error> {
+    pub fn version_exchange(&self, versions: &mut [f64]) -> Result<f64, MobileBackup2Error> {
         let mut version = 0.0;
         let result = unsafe {
             unsafe_bindings::mobilebackup2_version_exchange(


### PR DESCRIPTION
Use slices as arguments wherever possible. These function don't need to own vectors, they just need slices.
This is a semver breaking change.