### PR TITLE
Fix map_or() usages & handle `sbservices_get_icon_pngdata` returning a null pointer 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,7 +474,7 @@ dependencies = [
 
 [[package]]
 name = "rusty_libimobiledevice"
-version = "0.1.11"
+version = "0.2.0"
 dependencies = [
  "autotools",
  "bindgen",

--- a/src/services/instproxy.rs
+++ b/src/services/instproxy.rs
@@ -197,7 +197,7 @@ impl InstProxyClient<'_> {
         info!("Instproxy install");
         let pkg_path_c_string = CString::new(pkg_path.into()).unwrap();
 
-        let ptr = client_options.map_or(std::ptr::null_mut(), |v| v.get_pointer());
+        let ptr = client_options.as_ref().map_or(std::ptr::null_mut(), |v| v.get_pointer());
 
         let result = unsafe {
             unsafe_bindings::instproxy_install(
@@ -232,7 +232,7 @@ impl InstProxyClient<'_> {
         info!("Instproxy upgrade");
         let pkg_path_c_string = CString::new(pkg_path.into()).unwrap();
 
-        let ptr = client_options.map_or(std::ptr::null_mut(), |v| v.get_pointer());
+        let ptr = client_options.as_ref().map_or(std::ptr::null_mut(), |v| v.get_pointer());
 
         let result = unsafe {
             unsafe_bindings::instproxy_upgrade(
@@ -267,7 +267,7 @@ impl InstProxyClient<'_> {
         info!("Instproxy uninstall");
         let app_id_c_string = CString::new(app_id.into()).unwrap();
 
-        let ptr = client_options.map_or(std::ptr::null_mut(), |v| v.get_pointer());
+        let ptr = client_options.as_ref().map_or(std::ptr::null_mut(), |v| v.get_pointer());
 
         let result = unsafe {
             unsafe_bindings::instproxy_uninstall(
@@ -297,7 +297,7 @@ impl InstProxyClient<'_> {
         let mut res_plist: unsafe_bindings::plist_t = unsafe { std::mem::zeroed() };
         info!("Instproxy lookup archives");
 
-        let ptr = client_options.map_or(std::ptr::null_mut(), |v| v.get_pointer());
+        let ptr = client_options.as_ref().map_or(std::ptr::null_mut(), |v| v.get_pointer());
 
         let result = unsafe {
             unsafe_bindings::instproxy_lookup_archives(self.pointer, ptr, &mut res_plist)
@@ -326,7 +326,7 @@ impl InstProxyClient<'_> {
         info!("Instproxy archive");
         let app_id_c_string = CString::new(app_id.into()).unwrap();
 
-        let ptr = client_options.map_or(std::ptr::null_mut(), |v| v.get_pointer());
+        let ptr = client_options.as_ref().map_or(std::ptr::null_mut(), |v| v.get_pointer());
 
         let result = unsafe {
             unsafe_bindings::instproxy_archive(
@@ -360,7 +360,7 @@ impl InstProxyClient<'_> {
         info!("Instproxy restore");
         let app_id_c_string = CString::new(app_id.into()).unwrap();
 
-        let ptr = client_options.map_or(std::ptr::null_mut(), |v| v.get_pointer());
+        let ptr = client_options.as_ref().map_or(std::ptr::null_mut(), |v| v.get_pointer());
 
         let result = unsafe {
             unsafe_bindings::instproxy_restore(
@@ -394,7 +394,7 @@ impl InstProxyClient<'_> {
         info!("Instproxy remove archive");
         let app_id_c_string = CString::new(app_id.into()).unwrap();
 
-        let ptr = client_options.map_or(std::ptr::null_mut(), |v| v.get_pointer());
+        let ptr = client_options.as_ref().map_or(std::ptr::null_mut(), |v| v.get_pointer());
 
         let result = unsafe {
             unsafe_bindings::instproxy_remove_archive(
@@ -434,7 +434,7 @@ impl InstProxyClient<'_> {
         }
         capabilities_c_str_ptrs.push(std::ptr::null());
 
-        let ptr = client_options.map_or(std::ptr::null_mut(), |v| v.get_pointer());
+        let ptr = client_options.as_ref().map_or(std::ptr::null_mut(), |v| v.get_pointer());
 
         let result = unsafe {
             unsafe_bindings::instproxy_check_capabilities_match(

--- a/src/services/mobile_backup.rs
+++ b/src/services/mobile_backup.rs
@@ -138,7 +138,7 @@ impl MobileBackupClient<'_> {
         base_path: impl Into<String>,
         backup_version: impl Into<String>,
     ) -> Result<(), MobileBackupError> {
-        let ptr = manifest.map_or(std::ptr::null_mut(), |v| v.get_pointer());
+        let ptr = manifest.as_ref().map_or(std::ptr::null_mut(), |v| v.get_pointer());
 
         let base_path_c_string = CString::new(base_path.into()).unwrap();
         let backup_version_c_string = CString::new(backup_version.into()).unwrap();
@@ -374,7 +374,7 @@ impl MobileBackup2Client<'_> {
         options: Plist,
     ) -> Result<(), MobileBackup2Error> {
         let message_c_string = message.map(|s| CString::new(s).unwrap());
-        let message_c_string_ptr = message_c_string.map_or(std::ptr::null(), |s| s.as_ptr());
+        let message_c_string_ptr = message_c_string.as_ref().map_or(std::ptr::null(), |s| s.as_ptr());
 
         let result = unsafe {
             unsafe_bindings::mobilebackup2_send_message(
@@ -545,9 +545,9 @@ impl MobileBackup2Client<'_> {
         status_string: Option<String>,
         status_plist: Option<Plist>,
     ) -> Result<(), MobileBackup2Error> {
-        let status_plist = status_plist.map_or(std::ptr::null_mut(), |s| s.get_pointer());
+        let status_plist = status_plist.as_ref().map_or(std::ptr::null_mut(), |s| s.get_pointer());
         let status_c_string = status_string.map(|s| CString::new(s).unwrap());
-        let status_c_string_ptr = status_c_string.map_or(std::ptr::null(), |s| s.as_ptr());
+        let status_c_string_ptr = status_c_string.as_ref().map_or(std::ptr::null(), |s| s.as_ptr());
 
         let result = unsafe {
             unsafe_bindings::mobilebackup2_send_status_response(

--- a/src/services/mobile_sync.rs
+++ b/src/services/mobile_sync.rs
@@ -342,7 +342,7 @@ impl MobileSyncClient<'_> {
         is_last: bool,
         actions: Option<Plist>,
     ) -> Result<(), MobileSyncError> {
-        let actions = actions.map_or(std::ptr::null_mut(), |v| v.get_pointer());
+        let actions = actions.as_ref().map_or(std::ptr::null_mut(), |v| v.get_pointer());
 
         let result = unsafe {
             unsafe_bindings::mobilesync_send_changes(

--- a/src/services/preboard.rs
+++ b/src/services/preboard.rs
@@ -125,7 +125,7 @@ impl PreboardClient<'_> {
         let result = unsafe {
             unsafe_bindings::preboard_create_stashbag(
                 self.pointer,
-                manifest.map_or(std::ptr::null_mut(), |p| p.get_pointer()),
+                manifest.as_ref().map_or(std::ptr::null_mut(), |p| p.get_pointer()),
                 None,
                 std::ptr::null_mut(),
             )
@@ -150,7 +150,7 @@ impl PreboardClient<'_> {
         let result = unsafe {
             unsafe_bindings::preboard_commit_stashbag(
                 self.pointer,
-                manifest.map_or(std::ptr::null_mut(), |p| p.get_pointer()),
+                manifest.as_ref().map_or(std::ptr::null_mut(), |p| p.get_pointer()),
                 None,
                 std::ptr::null_mut(),
             )

--- a/src/services/restored.rs
+++ b/src/services/restored.rs
@@ -168,7 +168,7 @@ impl RestoredClient<'_> {
     ///
     /// ***Verified:*** False
     pub fn start_restore(&self, options: Option<Plist>, version: u64) -> Result<(), RestoredError> {
-        let ptr = options.map_or(std::ptr::null_mut(), |v| v.get_pointer());
+        let ptr = options.as_ref().map_or(std::ptr::null_mut(), |v| v.get_pointer());
 
         let result =
             unsafe { unsafe_bindings::restored_start_restore(self.pointer, ptr, version) }.into();

--- a/src/services/springboard_services.rs
+++ b/src/services/springboard_services.rs
@@ -88,7 +88,7 @@ impl SpringboardServicesClient<'_> {
         let mut plist = std::ptr::null_mut();
         let format_version_c_string = format_version.map(|s| CString::new(s).unwrap());
         let format_version_c_string_ptr =
-            format_version_c_string.map_or(std::ptr::null(), |s| s.as_ptr());
+            format_version_c_string.as_ref().map_or(std::ptr::null(), |s| s.as_ptr());
 
         let result = unsafe {
             unsafe_bindings::sbservices_get_icon_state(

--- a/src/services/springboard_services.rs
+++ b/src/services/springboard_services.rs
@@ -154,12 +154,13 @@ impl SpringboardServicesClient<'_> {
             return Err(result);
         }
 
-        let mut vec = Vec::with_capacity(size as usize);
-        unsafe {
-            std::ptr::copy_nonoverlapping(data, vec.as_mut_ptr(), size as usize);
+        if data == 0 as *mut u8 {
+            Ok(Vec::new())
+        } else {
+            Ok(unsafe {
+                std::slice::from_raw_parts(data, size as usize).to_vec()
+            })
         }
-
-        Ok(vec)
     }
 
     /// Gets the orientation of the device


### PR DESCRIPTION
* Fix map_or() dropping an underlying value 
Using `map_or()` on an `Option` to get a pointer for a CString or a Plist results in dropping the underlying value, thus a pointer is invalid. To prevent this we use `as_ref()` to get an option with a reference to a value which won't be
dropped.

* Update Cargo.lock

* Handle `sbservices_get_icon_pngdata` returning a null pointer
By running some tests, I found out that the function may not return an error and also leave an array uninitialized. Weather it's a bug or not, we need to handle this in Rust, or else it causes a panic.