### PR TITLE
mobile_backup: Fix incorrect memory allocation

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -116,7 +116,12 @@ impl ServiceClient<'_> {
         let mut data = vec![0 as u8; size as usize];
         let mut received = 0;
         let result = unsafe {
-            unsafe_bindings::service_receive(self.pointer, data.as_mut_ptr() as *mut c_char, size, &mut received)
+            unsafe_bindings::service_receive(
+                self.pointer,
+                data.as_mut_ptr() as *mut c_char,
+                size,
+                &mut received,
+            )
         }
         .into();
 
@@ -137,11 +142,7 @@ impl ServiceClient<'_> {
     /// The received data as a vector of bytes
     ///
     /// ***Verified:*** False
-    pub fn receive_with_timeout(
-        &self,
-        size: u32,
-        timeout: u32,
-    ) -> Result<Vec<u8>, ServiceError> {
+    pub fn receive_with_timeout(&self, size: u32, timeout: u32) -> Result<Vec<u8>, ServiceError> {
         let mut data = Vec::with_capacity(size as usize);
         let mut received = 0;
         let result = unsafe {

--- a/src/services/debug_server.rs
+++ b/src/services/debug_server.rs
@@ -251,7 +251,7 @@ impl DebugServer<'_> {
     ///
     /// ***Verified:*** False
     pub fn set_argv(&self, args: Vec<String>) -> Result<String, DebugServerError> {
-        let mut argv = Vec::with_capacity(args.len()+1);
+        let mut argv = Vec::with_capacity(args.len() + 1);
         let mut c_strings = Vec::with_capacity(args.len());
         for arg in args {
             c_strings.push(CString::new(arg).unwrap());

--- a/src/services/instproxy.rs
+++ b/src/services/instproxy.rs
@@ -197,7 +197,9 @@ impl InstProxyClient<'_> {
         info!("Instproxy install");
         let pkg_path_c_string = CString::new(pkg_path.into()).unwrap();
 
-        let ptr = client_options.as_ref().map_or(std::ptr::null_mut(), |v| v.get_pointer());
+        let ptr = client_options
+            .as_ref()
+            .map_or(std::ptr::null_mut(), |v| v.get_pointer());
 
         let result = unsafe {
             unsafe_bindings::instproxy_install(
@@ -232,7 +234,9 @@ impl InstProxyClient<'_> {
         info!("Instproxy upgrade");
         let pkg_path_c_string = CString::new(pkg_path.into()).unwrap();
 
-        let ptr = client_options.as_ref().map_or(std::ptr::null_mut(), |v| v.get_pointer());
+        let ptr = client_options
+            .as_ref()
+            .map_or(std::ptr::null_mut(), |v| v.get_pointer());
 
         let result = unsafe {
             unsafe_bindings::instproxy_upgrade(
@@ -267,7 +271,9 @@ impl InstProxyClient<'_> {
         info!("Instproxy uninstall");
         let app_id_c_string = CString::new(app_id.into()).unwrap();
 
-        let ptr = client_options.as_ref().map_or(std::ptr::null_mut(), |v| v.get_pointer());
+        let ptr = client_options
+            .as_ref()
+            .map_or(std::ptr::null_mut(), |v| v.get_pointer());
 
         let result = unsafe {
             unsafe_bindings::instproxy_uninstall(
@@ -297,7 +303,9 @@ impl InstProxyClient<'_> {
         let mut res_plist: unsafe_bindings::plist_t = unsafe { std::mem::zeroed() };
         info!("Instproxy lookup archives");
 
-        let ptr = client_options.as_ref().map_or(std::ptr::null_mut(), |v| v.get_pointer());
+        let ptr = client_options
+            .as_ref()
+            .map_or(std::ptr::null_mut(), |v| v.get_pointer());
 
         let result = unsafe {
             unsafe_bindings::instproxy_lookup_archives(self.pointer, ptr, &mut res_plist)
@@ -326,7 +334,9 @@ impl InstProxyClient<'_> {
         info!("Instproxy archive");
         let app_id_c_string = CString::new(app_id.into()).unwrap();
 
-        let ptr = client_options.as_ref().map_or(std::ptr::null_mut(), |v| v.get_pointer());
+        let ptr = client_options
+            .as_ref()
+            .map_or(std::ptr::null_mut(), |v| v.get_pointer());
 
         let result = unsafe {
             unsafe_bindings::instproxy_archive(
@@ -360,7 +370,9 @@ impl InstProxyClient<'_> {
         info!("Instproxy restore");
         let app_id_c_string = CString::new(app_id.into()).unwrap();
 
-        let ptr = client_options.as_ref().map_or(std::ptr::null_mut(), |v| v.get_pointer());
+        let ptr = client_options
+            .as_ref()
+            .map_or(std::ptr::null_mut(), |v| v.get_pointer());
 
         let result = unsafe {
             unsafe_bindings::instproxy_restore(
@@ -394,7 +406,9 @@ impl InstProxyClient<'_> {
         info!("Instproxy remove archive");
         let app_id_c_string = CString::new(app_id.into()).unwrap();
 
-        let ptr = client_options.as_ref().map_or(std::ptr::null_mut(), |v| v.get_pointer());
+        let ptr = client_options
+            .as_ref()
+            .map_or(std::ptr::null_mut(), |v| v.get_pointer());
 
         let result = unsafe {
             unsafe_bindings::instproxy_remove_archive(
@@ -427,14 +441,16 @@ impl InstProxyClient<'_> {
     ) -> Result<Plist, InstProxyError> {
         let mut res_plist = unsafe { std::mem::zeroed() };
         let mut capabilities_c_str = Vec::with_capacity(capabilities.len());
-        let mut capabilities_c_str_ptrs = Vec::with_capacity(capabilities.len()+1);
+        let mut capabilities_c_str_ptrs = Vec::with_capacity(capabilities.len() + 1);
         for capability in capabilities {
             capabilities_c_str.push(CString::new(capability).unwrap());
             capabilities_c_str_ptrs.push(capabilities_c_str.last().unwrap().as_ptr())
         }
         capabilities_c_str_ptrs.push(std::ptr::null());
 
-        let ptr = client_options.as_ref().map_or(std::ptr::null_mut(), |v| v.get_pointer());
+        let ptr = client_options
+            .as_ref()
+            .map_or(std::ptr::null_mut(), |v| v.get_pointer());
 
         let result = unsafe {
             unsafe_bindings::instproxy_check_capabilities_match(

--- a/src/services/lockdownd.rs
+++ b/src/services/lockdownd.rs
@@ -264,8 +264,7 @@ impl LockdowndClient<'_> {
             return Err(result);
         }
 
-        let service_struct: &unsafe_bindings::lockdownd_service_descriptor =
-            unsafe { &*service };
+        let service_struct: &unsafe_bindings::lockdownd_service_descriptor = unsafe { &*service };
 
         Ok(LockdowndService {
             pointer: service,

--- a/src/services/mobile_backup.rs
+++ b/src/services/mobile_backup.rs
@@ -454,11 +454,11 @@ impl MobileBackup2Client<'_> {
     ///
     /// ***Verified:*** False
     pub fn receive_raw(&self, len: u32) -> Result<Vec<u8>, MobileBackup2Error> {
-        let data: u8 = unsafe { std::mem::zeroed() };
+        let mut data: Vec<u8> = vec![0; len as usize];
         let mut received = 0;
 
         let result = unsafe {
-            unsafe_bindings::mobilebackup2_receive_raw(self.pointer, &mut (data as c_char), len, &mut received)
+            unsafe_bindings::mobilebackup2_receive_raw(self.pointer, data.as_mut_ptr() as *mut c_char, len, &mut received)
         }
         .into();
 
@@ -466,9 +466,8 @@ impl MobileBackup2Client<'_> {
             return Err(result);
         }
 
-        Ok(unsafe {
-            std::slice::from_raw_parts(&data, received as usize).to_vec()
-        })
+        data.truncate(received as usize);
+        Ok(data)
     }
 
     /// Exchanges version with the service

--- a/src/services/mobile_backup.rs
+++ b/src/services/mobile_backup.rs
@@ -138,7 +138,9 @@ impl MobileBackupClient<'_> {
         base_path: impl Into<String>,
         backup_version: impl Into<String>,
     ) -> Result<(), MobileBackupError> {
-        let ptr = manifest.as_ref().map_or(std::ptr::null_mut(), |v| v.get_pointer());
+        let ptr = manifest
+            .as_ref()
+            .map_or(std::ptr::null_mut(), |v| v.get_pointer());
 
         let base_path_c_string = CString::new(base_path.into()).unwrap();
         let backup_version_c_string = CString::new(backup_version.into()).unwrap();
@@ -374,7 +376,9 @@ impl MobileBackup2Client<'_> {
         options: Plist,
     ) -> Result<(), MobileBackup2Error> {
         let message_c_string = message.map(|s| CString::new(s).unwrap());
-        let message_c_string_ptr = message_c_string.as_ref().map_or(std::ptr::null(), |s| s.as_ptr());
+        let message_c_string_ptr = message_c_string
+            .as_ref()
+            .map_or(std::ptr::null(), |s| s.as_ptr());
 
         let result = unsafe {
             unsafe_bindings::mobilebackup2_send_message(
@@ -458,7 +462,12 @@ impl MobileBackup2Client<'_> {
         let mut received = 0;
 
         let result = unsafe {
-            unsafe_bindings::mobilebackup2_receive_raw(self.pointer, data.as_mut_ptr() as *mut c_char, len, &mut received)
+            unsafe_bindings::mobilebackup2_receive_raw(
+                self.pointer,
+                data.as_mut_ptr() as *mut c_char,
+                len,
+                &mut received,
+            )
         }
         .into();
 
@@ -544,9 +553,13 @@ impl MobileBackup2Client<'_> {
         status_string: Option<String>,
         status_plist: Option<Plist>,
     ) -> Result<(), MobileBackup2Error> {
-        let status_plist = status_plist.as_ref().map_or(std::ptr::null_mut(), |s| s.get_pointer());
+        let status_plist = status_plist
+            .as_ref()
+            .map_or(std::ptr::null_mut(), |s| s.get_pointer());
         let status_c_string = status_string.map(|s| CString::new(s).unwrap());
-        let status_c_string_ptr = status_c_string.as_ref().map_or(std::ptr::null(), |s| s.as_ptr());
+        let status_c_string_ptr = status_c_string
+            .as_ref()
+            .map_or(std::ptr::null(), |s| s.as_ptr());
 
         let result = unsafe {
             unsafe_bindings::mobilebackup2_send_status_response(

--- a/src/services/mobile_sync.rs
+++ b/src/services/mobile_sync.rs
@@ -135,7 +135,7 @@ impl MobileSyncClient<'_> {
     ) -> Result<(), (String, MobileSyncError)> {
         let data_class_c_string = CString::new(data_class.into()).unwrap();
 
-        let mut anchor_ptrs = Vec::with_capacity(anchors.len()+1);
+        let mut anchor_ptrs = Vec::with_capacity(anchors.len() + 1);
         for i in anchors {
             anchor_ptrs.push(unsafe_bindings::mobilesync_anchors_t::from(i));
         }
@@ -342,7 +342,9 @@ impl MobileSyncClient<'_> {
         is_last: bool,
         actions: Option<Plist>,
     ) -> Result<(), MobileSyncError> {
-        let actions = actions.as_ref().map_or(std::ptr::null_mut(), |v| v.get_pointer());
+        let actions = actions
+            .as_ref()
+            .map_or(std::ptr::null_mut(), |v| v.get_pointer());
 
         let result = unsafe {
             unsafe_bindings::mobilesync_send_changes(

--- a/src/services/notification_proxy.rs
+++ b/src/services/notification_proxy.rs
@@ -126,7 +126,6 @@ impl NotificationProxyClient<'_> {
         for notification in notifications {
             not_c_strings.push(CString::new(notification).unwrap());
             not_ptrs.push(not_c_strings.last().unwrap().as_ptr());
-
         }
         not_ptrs.push(std::ptr::null());
 

--- a/src/services/preboard.rs
+++ b/src/services/preboard.rs
@@ -125,7 +125,9 @@ impl PreboardClient<'_> {
         let result = unsafe {
             unsafe_bindings::preboard_create_stashbag(
                 self.pointer,
-                manifest.as_ref().map_or(std::ptr::null_mut(), |p| p.get_pointer()),
+                manifest
+                    .as_ref()
+                    .map_or(std::ptr::null_mut(), |p| p.get_pointer()),
                 None,
                 std::ptr::null_mut(),
             )
@@ -150,7 +152,9 @@ impl PreboardClient<'_> {
         let result = unsafe {
             unsafe_bindings::preboard_commit_stashbag(
                 self.pointer,
-                manifest.as_ref().map_or(std::ptr::null_mut(), |p| p.get_pointer()),
+                manifest
+                    .as_ref()
+                    .map_or(std::ptr::null_mut(), |p| p.get_pointer()),
                 None,
                 std::ptr::null_mut(),
             )

--- a/src/services/restored.rs
+++ b/src/services/restored.rs
@@ -168,7 +168,9 @@ impl RestoredClient<'_> {
     ///
     /// ***Verified:*** False
     pub fn start_restore(&self, options: Option<Plist>, version: u64) -> Result<(), RestoredError> {
-        let ptr = options.as_ref().map_or(std::ptr::null_mut(), |v| v.get_pointer());
+        let ptr = options
+            .as_ref()
+            .map_or(std::ptr::null_mut(), |v| v.get_pointer());
 
         let result =
             unsafe { unsafe_bindings::restored_start_restore(self.pointer, ptr, version) }.into();

--- a/src/services/springboard_services.rs
+++ b/src/services/springboard_services.rs
@@ -87,8 +87,9 @@ impl SpringboardServicesClient<'_> {
     pub fn get_icon_state(&self, format_version: Option<String>) -> Result<Plist, SbservicesError> {
         let mut plist = std::ptr::null_mut();
         let format_version_c_string = format_version.map(|s| CString::new(s).unwrap());
-        let format_version_c_string_ptr =
-            format_version_c_string.as_ref().map_or(std::ptr::null(), |s| s.as_ptr());
+        let format_version_c_string_ptr = format_version_c_string
+            .as_ref()
+            .map_or(std::ptr::null(), |s| s.as_ptr());
 
         let result = unsafe {
             unsafe_bindings::sbservices_get_icon_state(
@@ -157,9 +158,7 @@ impl SpringboardServicesClient<'_> {
         if data == 0 as *mut u8 {
             Ok(Vec::new())
         } else {
-            Ok(unsafe {
-                std::slice::from_raw_parts(data, size as usize).to_vec()
-            })
+            Ok(unsafe { std::slice::from_raw_parts(data, size as usize).to_vec() })
         }
     }
 


### PR DESCRIPTION
We need to pass a pointer of an allocated array to the underlying function.