### PR TITLE
instproxy: Introduce `browse_with_options`

### DIFF
--- a/src/services/instproxy.rs
+++ b/src/services/instproxy.rs
@@ -84,6 +84,32 @@ impl InstProxyClient<'_> {
         Ok(plist.into())
     }
 
+    /// Lists installed applications on the device using an option plist
+    /// # Arguments
+    /// * `client_options` - A plist containing options for the lookup.
+    /// # Returns
+    /// A plist with a list of applications
+    ///
+    /// ***Verified:*** False
+    pub fn browse_with_options(&self, client_options: Plist) -> Result<Plist, InstProxyError> {
+        let mut plist = std::ptr::null_mut();
+
+        let result = unsafe {
+            unsafe_bindings::instproxy_browse(
+                self.pointer,
+                client_options.get_pointer(),
+                &mut plist,
+            )
+        }
+        .into();
+
+        if result != InstProxyError::Success {
+            return Err(result);
+        }
+
+        Ok(plist.into())
+    }
+
     /// Creates a Plist containing return attributes for lookup
     /// # Arguments
     /// * `options` - The options for lookup


### PR DESCRIPTION
Using `BrowseOption` may not be enough for some requests, it's only useful if the "ApplicationType" option is needed. However, there are other options such as `ApplicationSINF`, `iTunesMetadata`, `BundleIDs` and more. Also, one may want to include return attributes as well.

The `browse_with_options` method of `InstProxyClient` allows users to set their own options and return attributes, remaining the compatibility.